### PR TITLE
identify table rows by ptd number not index, so that we know which it…

### DIFF
--- a/src/web/views/componentViews/checker/referred/referredView.html
+++ b/src/web/views/componentViews/checker/referred/referredView.html
@@ -160,9 +160,9 @@
             const identifier = button.getAttribute('data-identifier');
 
             // Check if this link was clicked before
-            if (localStorage.getItem(identifier)) { // sems to be adding visited to all but the 5th entry 
+            if (localStorage.getItem(identifier)) {
                 button.classList.add('visited');
-            }// something is happening here, adding the visited class
+            }
 
             button.addEventListener('click', function () {
                 // Mark this link as visited

--- a/src/web/views/componentViews/checker/referred/referredView.html
+++ b/src/web/views/componentViews/checker/referred/referredView.html
@@ -69,7 +69,7 @@
                             <th scope="row" class="govuk-table__header">
                                 <form method="POST" action="/checker/checkreport" class="referred-form">
                                     <button type="submit" class="govuk-button--link referred-button"
-                                        data-identifier="referred-{{ loop.index }}">
+                                        data-identifier="referred-{{ spsCheck.PTDNumber }}">
                                         {{spsCheck.PTDNumberFormatted}}<span class="govuk-visually-hidden"> reported</span>
                                     </button>
                                     <input type="hidden" name="CheckSummaryId" value="{{ spsCheck.CheckSummaryId }}">                                    
@@ -160,9 +160,9 @@
             const identifier = button.getAttribute('data-identifier');
 
             // Check if this link was clicked before
-            if (localStorage.getItem(identifier)) {
+            if (localStorage.getItem(identifier)) { // sems to be adding visited to all but the 5th entry 
                 button.classList.add('visited');
-            }
+            }// something is happening here, adding the visited class
 
             button.addEventListener('click', function () {
                 // Mark this link as visited


### PR DESCRIPTION
Identify table rows by PTD number, not index, so that we know which items have been visited regardless of their position in the table.

it seems that localstorage was storage row indices but what if items got removed and crucially, when pagination happens, we still have the same indices being used to highlight items that were visited. 

instead we uniquely identify rows by PTD number, store those in storge if visited

resolves https://dev.azure.com/defragovuk/DEFRA-PET-TRAVEL/_workitems/edit/503291