### PR TITLE
include isGBCheck in array, in between the comments ids to cover case…

### DIFF
--- a/src/web/component/checker/noncompliance/handler.js
+++ b/src/web/component/checker/noncompliance/handler.js
@@ -32,6 +32,7 @@ const fieldIdSortOrdering = [ // add more fields if needed
   'passengerType',
   'relevantComments',
   'spsOutcome',
+  'isGBCheck',
   'spsOutcomeDetails',
 ]
 


### PR DESCRIPTION
… when user is logged in as gb checker so the gb check field shows in right order


resolves https://dev.azure.com/defragovuk/DEFRA-PET-TRAVEL/_workitems/edit/545166 (specifically QA comment)